### PR TITLE
Remove duplicate grid class

### DIFF
--- a/src/components/layout/RootLayout.tsx
+++ b/src/components/layout/RootLayout.tsx
@@ -31,7 +31,7 @@ interface RootLayoutProps {
 export function RootLayout({ children }: RootLayoutProps) {
   return (
     <html lang="en" className={`${courierPrime.variable} ${inter.variable} ${roboto.variable} ${montserrat.variable}`}>
-      <body className="grid grid h-screen grid-cols-[1fr_auto] grid-rows-[2fr_1fr] gap-2">
+      <body className="grid h-screen grid-cols-[1fr_auto] grid-rows-[2fr_1fr] gap-2">
         <main className="col-span-1 font-montserrat">
           {children}
         </main>


### PR DESCRIPTION
## Summary
- fix duplicate `grid` class in `RootLayout`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fef8d1c8c832391034c6b9757dbe0