### PR TITLE
Add component tests for blog posts

### DIFF
--- a/src/components/cards/__tests__/BlogPostCard.test.tsx
+++ b/src/components/cards/__tests__/BlogPostCard.test.tsx
@@ -1,0 +1,26 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { BlogPostCard } from '../BlogPostCard'
+import { BlogPost } from '@/lib/firebase/blogs'
+
+describe('BlogPostCard', () => {
+  const post: BlogPost = {
+    id: '1',
+    title: 'Test Title',
+    description: 'Test Description',
+    content: 'Content',
+    main_image: 'image.jpg',
+    published: true,
+    published_date: new Date('2024-01-01'),
+    readTime: '1 min',
+    imageUrl: 'https://example.com/image.jpg',
+  }
+
+  it('displays title, description and link', () => {
+    render(<BlogPostCard post={post} isLeft={false} />)
+    expect(screen.getByRole('heading', { name: post.title })).toBeInTheDocument()
+    expect(screen.getByText(post.description)).toBeInTheDocument()
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('href', `/blog/${post.id}`)
+  })
+})

--- a/src/components/cards/__tests__/BlogPosts.test.tsx
+++ b/src/components/cards/__tests__/BlogPosts.test.tsx
@@ -1,0 +1,49 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { BlogPosts } from '../BlogPosts'
+import { fetchBlogs } from '@/lib/firebase/blogs'
+import { BlogPost } from '@/lib/firebase/blogs'
+
+jest.mock('@/lib/firebase/blogs', () => ({
+  fetchBlogs: jest.fn(),
+}))
+
+describe('BlogPosts', () => {
+  const posts: BlogPost[] = [
+    {
+      id: '1',
+      title: 'First Post',
+      description: 'First description',
+      content: 'content',
+      main_image: 'img1.jpg',
+      published: true,
+      published_date: new Date('2024-01-01'),
+      readTime: '2 min',
+      imageUrl: 'https://example.com/1.jpg',
+    },
+    {
+      id: '2',
+      title: 'Second Post',
+      description: 'Second description',
+      content: 'content',
+      main_image: 'img2.jpg',
+      published: true,
+      published_date: new Date('2024-01-02'),
+      readTime: '3 min',
+      imageUrl: 'https://example.com/2.jpg',
+    },
+  ]
+
+  it('renders a list of BlogPostCards', async () => {
+    ;(fetchBlogs as jest.Mock).mockResolvedValue(posts)
+    const element = await BlogPosts()
+    render(element)
+
+    expect(fetchBlogs).toHaveBeenCalled()
+    // There should be as many links as posts since each card is wrapped in a link
+    const links = screen.getAllByRole('link')
+    expect(links).toHaveLength(posts.length)
+    expect(screen.getByText(posts[0].title)).toBeInTheDocument()
+    expect(screen.getByText(posts[1].description)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- add tests for `BlogPostCard` component
- add tests for `BlogPosts` list component mocking `fetchBlogs`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840327e650c8323bf16ab6a3c8ef118