### PR TITLE
Add shared revalidate constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ src/
 ### Performance
 - Optimize images and assets
 - Implement proper caching
+- Firebase-powered pages revalidate every hour to keep content fresh. The interval is defined by `REVALIDATE_INTERVAL` in `src/lib/constants.ts`.
 - Minimize client-side JavaScript
 - Use React Server Components where possible
 
@@ -157,4 +158,4 @@ The application will be deployed on Firebase Hosting. Follow these steps:
 
 ## License
 
-This project is licensed under the MIT License. 
+This project is licensed under the MIT License.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "your-blog",
+  "name": "Titas Blog",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "your-blog",
+      "name": "Titas Blog",
       "version": "1.0.0",
       "dependencies": {
         "@tailwindcss/postcss": "^4.1.7",

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -2,6 +2,10 @@ import { notFound } from 'next/navigation'
 import { fetchBlogById } from '@/lib/firebase/blogs'
 import { Article } from '@/components/blog/Article'
 import { Metadata } from 'next'
+import { REVALIDATE_INTERVAL } from '@/lib/constants'
+
+// Revalidate the page every hour to keep blog data fresh
+export const revalidate = REVALIDATE_INTERVAL
 
 interface PageProps {
     params: Promise<{
@@ -54,4 +58,4 @@ export default async function BlogPostPage(props: PageProps) {
         console.error('Error fetching blog post:', error)
         notFound()
     }
-} 
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,10 @@
 import React from 'react'
 import { Hero } from '@/components/hero/Hero'
 import { BlogPosts } from '@/components/cards/BlogPosts'
+import { REVALIDATE_INTERVAL } from '@/lib/constants'
+
+// Revalidate the homepage every hour to refresh blog listings
+export const revalidate = REVALIDATE_INTERVAL
 
 export default function Home() {
   return (

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,1 @@
+export const REVALIDATE_INTERVAL = 3600 // seconds


### PR DESCRIPTION
## Summary
- centralize page revalidation interval in `src/lib/constants.ts`
- reference the constant from page routes
- document the constant in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684032885ad88323817832bf9739ba35