### PR TITLE
Fix node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Dependencies
-ARG NODE_VERSION=23.7.0
+ARG NODE_VERSION=20.11.1
 
 FROM node:${NODE_VERSION}-alpine AS deps
 WORKDIR /app


### PR DESCRIPTION
## Summary
- use Node 20 LTS in Dockerfile

## Testing
- `npm test`
- `docker build -t blog-test .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_684682e702b88323a542b0c39fc572e3