### PR TITLE
Fix Timestamp types in tests

### DIFF
--- a/src/components/cards/__tests__/BlogPostCard.test.tsx
+++ b/src/components/cards/__tests__/BlogPostCard.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom'
 import { render, screen } from '@testing-library/react'
 import { BlogPostCard } from '../BlogPostCard'
 import { BlogPost } from '@/lib/firebase/blogs'
+import { Timestamp } from 'firebase/firestore'
 
 describe('BlogPostCard', () => {
   const post: BlogPost = {
@@ -11,7 +12,7 @@ describe('BlogPostCard', () => {
     content: 'Content',
     main_image: 'image.jpg',
     published: true,
-    published_date: new Date('2024-01-01'),
+    published_date: Timestamp.fromDate(new Date('2024-01-01')),
     readTime: '1 min',
     imageUrl: 'https://example.com/image.jpg',
   }

--- a/src/components/cards/__tests__/BlogPosts.test.tsx
+++ b/src/components/cards/__tests__/BlogPosts.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react'
 import { BlogPosts } from '../BlogPosts'
 import { fetchBlogs } from '@/lib/firebase/blogs'
 import { BlogPost } from '@/lib/firebase/blogs'
+import { Timestamp } from 'firebase/firestore'
 
 jest.mock('@/lib/firebase/blogs', () => ({
   fetchBlogs: jest.fn(),
@@ -17,7 +18,7 @@ describe('BlogPosts', () => {
       content: 'content',
       main_image: 'img1.jpg',
       published: true,
-      published_date: new Date('2024-01-01'),
+      published_date: Timestamp.fromDate(new Date('2024-01-01')),
       readTime: '2 min',
       imageUrl: 'https://example.com/1.jpg',
     },
@@ -28,7 +29,7 @@ describe('BlogPosts', () => {
       content: 'content',
       main_image: 'img2.jpg',
       published: true,
-      published_date: new Date('2024-01-02'),
+      published_date: Timestamp.fromDate(new Date('2024-01-02')),
       readTime: '3 min',
       imageUrl: 'https://example.com/2.jpg',
     },

--- a/src/lib/firebase/__tests__/blogs.test.ts
+++ b/src/lib/firebase/__tests__/blogs.test.ts
@@ -1,4 +1,4 @@
-import { collection, getDocs, doc, getDoc, query, orderBy } from 'firebase/firestore'
+import { collection, getDocs, doc, getDoc, query, orderBy, Timestamp } from 'firebase/firestore'
 import { getDownloadURL, ref, StorageReference, FirebaseStorage } from 'firebase/storage'
 import { db, storage } from '../config'
 import { fetchBlogs, fetchBlogById, getImageUrl } from '../blogs'
@@ -40,7 +40,7 @@ describe('Blog API Functions', () => {
                     main_image: 'path/to/image1.jpg',
                     content: 'Content 1',
                     published: true,
-                    published_date: new Date(),
+                    published_date: Timestamp.fromDate(new Date()),
                     readTime: '5 min',
                     tags: ['test']
                 },
@@ -51,7 +51,7 @@ describe('Blog API Functions', () => {
                     main_image: 'path/to/image2.jpg',
                     content: 'Content 2',
                     published: true,
-                    published_date: new Date(),
+                    published_date: Timestamp.fromDate(new Date()),
                     readTime: '3 min',
                     tags: ['test']
                 }
@@ -102,7 +102,7 @@ describe('Blog API Functions', () => {
                 description: 'Description',
                 content: 'Content',
                 published: true,
-                published_date: new Date(),
+                published_date: Timestamp.fromDate(new Date()),
                 readTime: '5 min'
             }
 
@@ -132,7 +132,7 @@ describe('Blog API Functions', () => {
                 main_image: 'path/to/image.jpg',
                 content: 'Content',
                 published: true,
-                published_date: new Date(),
+                published_date: Timestamp.fromDate(new Date()),
                 readTime: '5 min'
             }
 
@@ -164,7 +164,7 @@ describe('Blog API Functions', () => {
                 description: 'Description',
                 content: 'Content',
                 published: true,
-                published_date: new Date(),
+                published_date: Timestamp.fromDate(new Date()),
                 readTime: '5 min'
             }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,8 @@
         "typeRoots": [
             "./node_modules/@types",
             "./src/types"
-        ]
+        ],
+        "types": ["node", "jest"]
     },
     "include": [
         "next-env.d.ts",


### PR DESCRIPTION
## Summary
- import Timestamp for mocks
- use `Timestamp.fromDate` in tests
- restrict TypeScript global types to avoid unused stub

## Testing
- `npx tsc --noEmit`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68468640f4088323ad607f0d0b87d4b5