### PR TITLE
Add sticky back button to blog posts

### DIFF
--- a/src/components/blog/Article.tsx
+++ b/src/components/blog/Article.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image'
+import Link from 'next/link'
 import { BlogPost } from '@/lib/firebase/blogs'
 import ReactMarkdown from 'react-markdown'
 import { Title } from '../ui/Title'
@@ -12,6 +13,12 @@ export function Article({ post }: ArticleProps) {
 
     return (
         <article className="mx-auto">
+            {/* Back Button */}
+            <div className="sticky top-2 left-2 z-10 w-fit ml-2">
+                <Link href="/" className="inline-flex items-center gap-1 px-2 py-1 rounded bg-[var(--primary-color)] text-white">
+                    ← Back
+                </Link>
+            </div>
             {/* Hero Section with Image and Title */}
             <div className="relative w-full h-[45vh] mb-8 flex items-center justify-center">
                 <div className="relative w-full h-full">

--- a/src/components/blog/__tests__/Article.test.tsx
+++ b/src/components/blog/__tests__/Article.test.tsx
@@ -1,0 +1,27 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { Article } from '../Article'
+import { BlogPost } from '@/lib/firebase/blogs'
+
+jest.mock('react-markdown', () => {
+  const React = require('react')
+  return ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+})
+
+const post: BlogPost = {
+  id: '1',
+  title: 'My Post',
+  description: 'desc',
+  content: 'content',
+  main_image: 'image.jpg',
+  published: true,
+  published_date: new Date('2024-01-01'),
+  readTime: '1 min',
+  imageUrl: 'https://example.com/image.jpg'
+}
+
+test('renders back button linking to home page', () => {
+  render(<Article post={post} />)
+  const link = screen.getByRole('link', { name: /back/i })
+  expect(link).toHaveAttribute('href', '/')
+})


### PR DESCRIPTION
## Summary
- add a sticky back button to the `Article` component
- test back button rendering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686fb9229e248323b1f9aa391e6fdfd3